### PR TITLE
chore(bench): update CodSpeed/action to v2

### DIFF
--- a/.github/workflows/codespeed.yml
+++ b/.github/workflows/codespeed.yml
@@ -40,7 +40,7 @@ jobs:
         run: cd powerboxesrs && cargo codspeed build
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v1
+        uses: CodSpeedHQ/action@v2
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: pytest bindings/tests/ --codspeed && cd powerboxesrs && cargo codspeed run


### PR DESCRIPTION
Upgrading to the v2 of https://github.com/CodSpeedHQ/action will bring a better base run selection algorithm, better logging, and continued support.