### PR TITLE
perf: apply init-and-skip pattern to ciou and diou distance

### DIFF
--- a/powerboxesrs/benches/bench_iou.rs
+++ b/powerboxesrs/benches/bench_iou.rs
@@ -85,12 +85,8 @@ pub fn parallel_giou_distance_benchmark(c: &mut Criterion) {
 pub fn ciou_distance_benchmark(c: &mut Criterion) {
     let mut boxes1 = Array2::<f64>::zeros((100, 4));
     for i in 0..100 {
-        for j in 0..4 {
-            if j < 2 {
-                boxes1[[i, j]] = 0.0;
-            } else {
-                boxes1[[i, j]] = 10.0;
-            }
+        for j in 2..4 {
+            boxes1[[i, j]] = 10.0;
         }
     }
     let boxes2 = boxes1.clone();
@@ -103,12 +99,8 @@ pub fn ciou_distance_benchmark(c: &mut Criterion) {
 pub fn diou_distance_benchmark(c: &mut Criterion) {
     let mut boxes1 = Array2::<f64>::zeros((100, 4));
     for i in 0..100 {
-        for j in 0..4 {
-            if j < 2 {
-                boxes1[[i, j]] = 0.0;
-            } else {
-                boxes1[[i, j]] = 10.0;
-            }
+        for j in 2..4 {
+            boxes1[[i, j]] = 10.0;
         }
     }
     let boxes2 = boxes1.clone();

--- a/powerboxesrs/benches/bench_iou.rs
+++ b/powerboxesrs/benches/bench_iou.rs
@@ -1,5 +1,7 @@
 use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Criterion};
 use ndarray::Array2;
+use powerboxesrs::ciou::ciou_distance;
+use powerboxesrs::diou::diou_distance;
 use powerboxesrs::giou::{
     giou_distance, parallel_giou_distance, parallel_rotated_giou_distance, rotated_giou_distance,
 };
@@ -80,6 +82,42 @@ pub fn parallel_giou_distance_benchmark(c: &mut Criterion) {
     });
 }
 
+pub fn ciou_distance_benchmark(c: &mut Criterion) {
+    let mut boxes1 = Array2::<f64>::zeros((100, 4));
+    for i in 0..100 {
+        for j in 0..4 {
+            if j < 2 {
+                boxes1[[i, j]] = 0.0;
+            } else {
+                boxes1[[i, j]] = 10.0;
+            }
+        }
+    }
+    let boxes2 = boxes1.clone();
+
+    c.bench_function("ciou distance benchmark", |b| {
+        b.iter(|| ciou_distance(black_box(&boxes1), black_box(&boxes2)))
+    });
+}
+
+pub fn diou_distance_benchmark(c: &mut Criterion) {
+    let mut boxes1 = Array2::<f64>::zeros((100, 4));
+    for i in 0..100 {
+        for j in 0..4 {
+            if j < 2 {
+                boxes1[[i, j]] = 0.0;
+            } else {
+                boxes1[[i, j]] = 10.0;
+            }
+        }
+    }
+    let boxes2 = boxes1.clone();
+
+    c.bench_function("diou distance benchmark", |b| {
+        b.iter(|| diou_distance(black_box(&boxes1), black_box(&boxes2)))
+    });
+}
+
 /// Generate 100x5 rotated boxes with varied angles for benchmarking
 fn make_rotated_boxes(n: usize) -> Array2<f64> {
     let mut boxes = Array2::<f64>::zeros((n, 5));
@@ -154,6 +192,8 @@ criterion_group!(
     parallel_iou_distance_benchmark,
     giou_distance_benchmark,
     parallel_giou_distance_benchmark,
+    ciou_distance_benchmark,
+    diou_distance_benchmark,
     rotated_iou_distance_benchmark,
     parallel_rotated_iou_distance_benchmark,
     rotated_giou_distance_benchmark,

--- a/powerboxesrs/src/ciou.rs
+++ b/powerboxesrs/src/ciou.rs
@@ -28,7 +28,7 @@ where
 {
     let two = N::one() + N::one();
     let four_over_pi_sq: f64 = 4.0 / (std::f64::consts::PI * std::f64::consts::PI);
-    let mut result = vec![0.0f64; n1 * n2];
+    let mut result = vec![utils::ONE; n1 * n2];
     let areas1 = boxes::box_areas_slice(boxes1, n1);
     let areas2 = boxes::box_areas_slice(boxes2, n2);
 
@@ -44,7 +44,6 @@ where
             let x2 = utils::min(a1_x2, a2_x2);
             let y2 = utils::min(a1_y2, a2_y2);
             if x2 < x1 || y2 < y1 {
-                result[i * n2 + j] = utils::ONE;
                 continue;
             }
             let intersection = (x2 - x1) * (y2 - y1);

--- a/powerboxesrs/src/diou.rs
+++ b/powerboxesrs/src/diou.rs
@@ -24,7 +24,7 @@ where
     N: Num + PartialOrd + ToPrimitive + Float,
 {
     let two = N::one() + N::one();
-    let mut result = vec![0.0f64; n1 * n2];
+    let mut result = vec![utils::ONE; n1 * n2];
     let areas1 = boxes::box_areas_slice(boxes1, n1);
     let areas2 = boxes::box_areas_slice(boxes2, n2);
 
@@ -40,7 +40,6 @@ where
             let x2 = utils::min(a1_x2, a2_x2);
             let y2 = utils::min(a1_y2, a2_y2);
             if x2 < x1 || y2 < y1 {
-                result[i * n2 + j] = utils::ONE;
                 continue;
             }
             let intersection = (x2 - x1) * (y2 - y1);


### PR DESCRIPTION
## Summary

Follow-up to #85, applying the same `init-and-skip` pattern that gcanat used on `iou_distance_slice` to `ciou_distance_slice` and `diou_distance_slice`.

The pattern: pre-fill `result` with `utils::ONE` once, then `continue` on the no-overlap branch — instead of initializing to zeros and explicitly writing `result[idx] = ONE` per non-overlapping pair. One fewer write + one fewer index calculation in the no-overlap hot path.

Also adds `ciou_distance_benchmark` and `diou_distance_benchmark` (neither existed in `bench_iou.rs` before) so CodSpeed can measure the delta on this PR and on any future change to these functions.

Other distance functions are **not** eligible for this pattern:
- `giou_distance_slice` always computes the enclosing-box term and writes every cell unconditionally.
- `tiou_distance_slice` has no no-overlap branch at all.

## Test plan

- [x] `cd powerboxesrs && cargo test` — all 91 + 18 doctests pass.
- [x] `cd powerboxesrs && cargo test --no-default-features` — slice-only build, 52 + 2 doctests pass.
- [x] `cargo bench --bench bench_iou -- 'ciou distance|diou distance' --quick` — new benches run (ciou ~50 µs, diou ~30 µs on 100×100).
- [x] `cargo fmt --check` on both crates.
- [ ] CodSpeed: expect `ciou distance benchmark` and `diou distance benchmark` to appear in the report. If they show a regression or ~0% change, the LLVM optimizer was already eliding the redundant write — the refactor still stands as a readability cleanup.