### PR TITLE
fix(ci): drop i686 builds (pulp lacks 32-bit support)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,9 +201,6 @@ jobs:
         include:
           - os: linux
             manylinux: auto
-            target: i686
-          - os: linux
-            manylinux: auto
             target: aarch64
           - os: linux
             manylinux: auto
@@ -235,10 +232,6 @@ jobs:
           # windows
           - os: windows
             target: x86_64
-            interpreter: 3.9 3.10 3.11 3.12 3.13
-          - os: windows
-            target: i686
-            python-architecture: x86
             interpreter: 3.9 3.10 3.11 3.12 3.13
         exclude:
           - os: windows


### PR DESCRIPTION
## Problem

CI on `main` is failing on the two 32-bit (i686) build jobs:
- `build on linux (i686 - all - manylinux)`
- `build on windows (i686 - ...)`

Both fail with:
```
error: <inline asm>:5:15: register %rax is only available in 64-bit mode
error: could not compile `pulp` (lib)
```

## Root cause

PR #85 (linear sum assignment) added `perfect-matching = "0.1.0"` to `powerboxesrs`. Dependency chain:

```
powerboxesrs -> perfect-matching v0.1.0 -> pulp v0.20.1
```

`pulp` is a SIMD crate that emits x86-64-only inline asm (`vmovss xmm0, [rax + 0]`) and cannot compile for 32-bit targets. `perfect-matching` depends on `pulp` unconditionally (no feature gate), so there's no way to opt out while keeping the LSAP feature.

## Fix

Drop the `linux/i686` and `windows/i686` entries from the `build` matrix in `.github/workflows/ci.yml`. This is the minimal change to unblock `main`.

Trade-off: powerboxes will no longer publish 32-bit wheels (it did in older 0.1.x releases). Acceptable given the new LSAP dependency can't build for those targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)